### PR TITLE
fixes for building qxmoji on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,27 @@ to install qXmoji to the selected prefix and DESTDIR.
 If your default `make` tool is not GNU make, the latter is probably installed
 using the name `gmake` (e.g. on BSD systems), so type that instead of `make`.
 
+## Building on Linux (Debian / Ubuntu)
+
+Clone the current source tree with the needed submodules.
+
+    git clone git@github.com:jhx0/qxmoji.git --recurse-submodules
+
+Next install the needed dependencies.
+
+    sudo apt install qtbase5-dev libqt5x11extras5-dev libxcb-xtest0-dev -y
+    sudo apt install build-essential -y
+
+Change into the source directory and issue the make command as following.
+
+    make QT_VERSION=5
+
+After the building has finished you can find the resulting binary under:
+
+    bin/x86_64-linux-gnu/release/
+
+Note: Debian and Ubuntu currently do not ship Qt6. In order to build the code
+we need to leverage Qt5 as shown above.
+
+Tested on Debian 12 amd64 with GCC 12.2.0 (Debian 12.2.0-14)
+

--- a/README.md
+++ b/README.md
@@ -98,27 +98,13 @@ to install qXmoji to the selected prefix and DESTDIR.
 If your default `make` tool is not GNU make, the latter is probably installed
 using the name `gmake` (e.g. on BSD systems), so type that instead of `make`.
 
-## Building on Linux (Debian / Ubuntu)
+## Building on Debian / Ubuntu Linux
 
-Clone the current source tree with the needed submodules.
-
-    git clone git@github.com:jhx0/qxmoji.git --recurse-submodules
-
-Next install the needed dependencies.
+Install the needed dependencies.
 
     sudo apt install qtbase5-dev libqt5x11extras5-dev libxcb-xtest0-dev -y
     sudo apt install build-essential -y
 
-Change into the source directory and issue the make command as following.
+After that you can continue with the build instructions given above.  
 
-    make QT_VERSION=5
-
-After the building has finished you can find the resulting binary under:
-
-    bin/x86_64-linux-gnu/release/
-
-Note: Debian and Ubuntu currently do not ship Qt6. In order to build the code
-we need to leverage Qt5 as shown above.
-
-Tested on Debian 12 amd64 with GCC 12.2.0 (Debian 12.2.0-14)
-
+This was tested on Debian 12 amd64 with GCC 12.2.0 (Debian 12.2.0-14).

--- a/src/bin/qxmoji/main.c
+++ b/src/bin/qxmoji/main.c
@@ -1,7 +1,4 @@
-/* Needed to build on Linux */
-#ifdef __linux__
-#	define _GNU_SOURCE
-#endif
+#define _POSIX_C_SOURCE 200112L
 
 #include "guimain.h"
 

--- a/src/bin/qxmoji/main.c
+++ b/src/bin/qxmoji/main.c
@@ -1,3 +1,8 @@
+/* Needed to build on Linux */
+#ifdef __linux__
+#	define _GNU_SOURCE
+#endif
+
 #include "guimain.h"
 
 #include <signal.h>

--- a/src/bin/qxmoji/singleinstance.cpp
+++ b/src/bin/qxmoji/singleinstance.cpp
@@ -1,3 +1,5 @@
+#define _POSIX_C_SOURCE 200112L
+
 #include "singleinstance.h"
 
 #include <pwd.h>


### PR DESCRIPTION
Hello there @Zirias 

I made a few little changes to make qxmoji build/work on Linux.
The cultprit here was defining _GNU_SOURCE since many functions used (Signals) are only available when setting named constant. The application builds and runs without problems here on Debian 12.

I also took the liberty to alter the Readme to include instructions for Debian/Ubuntu systems.

Compiler output:
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-linux-gnu/12/lto-wrapper
OFFLOAD_TARGET_NAMES=nvptx-none:amdgcn-amdhsa
OFFLOAD_TARGET_DEFAULT=1
Target: x86_64-linux-gnu
Configured with: ../src/configure -v --with-pkgversion='Debian 12.2.0-14' --with-bugurl=file:///usr/share/doc/gcc-12/README.Bugs --enable-languages=c,ada,c++,go,d,fortran,objc,obj-c++,m2 --prefix=/usr --with-gcc-major-version-only --program-suffix=-12 --program-prefix=x86_64-linux-gnu- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nls --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-unique-object --disable-vtable-verify --enable-plugin --enable-default-pie --with-system-zlib --enable-libphobos-checking=release --with-target-system-zlib=auto --enable-objc-gc=auto --enable-multiarch --disable-werror --enable-cet --with-arch-32=i686 --with-abi=m64 --with-multilib-list=m32,m64,mx32 --enable-multilib --with-tune=generic --enable-offload-targets=nvptx-none=/build/gcc-12-bTRWOB/gcc-12-12.2.0/debian/tmp-nvptx/usr,amdgcn-amdhsa=/build/gcc-12-bTRWOB/gcc-12-12.2.0/debian/tmp-gcn/usr --enable-offload-defaulted --without-cuda-driver --enable-checking=release --build=x86_64-linux-gnu --host=x86_64-linux-gnu --target=x86_64-linux-gnu
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 12.2.0 (Debian 12.2.0-14)